### PR TITLE
Add PowerShell script for Windows installation

### DIFF
--- a/install-sendme.ps1
+++ b/install-sendme.ps1
@@ -1,0 +1,35 @@
+$repo = "n0-computer/sendme"
+$release_url = "https://api.github.com/repos/$repo/releases/latest"
+
+$target = "windows-x86_64"
+$zipFile = "sendme.zip"
+$extractPath = ".\sendme"
+
+Write-Host "Fetching latest release for $target..."
+$releaseJson = Invoke-RestMethod -Uri $release_url
+$releaseUrl = ($releaseJson.assets | Where-Object { $_.browser_download_url -match $target }).browser_download_url
+
+if (-not $releaseUrl) {
+    Write-Host "Error: No release found for $target" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Downloading from $releaseUrl..."
+Invoke-WebRequest -Uri $releaseUrl -OutFile $zipFile
+
+Write-Host "Extracting..."
+Expand-Archive -Path $zipFile -DestinationPath $extractPath -Force
+
+Write-Host "Cleaning up..."
+Remove-Item -Force $zipFile
+
+Write-Host "Installation complete!"
+
+# Add the 'sendme' folder to PATH
+$sendmePath = (Resolve-Path $extractPath).Path
+
+# Add the folder to the PATH permanently (user level)
+$env:Path += ";$sendmePath"
+[System.Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User)
+
+Write-Host "'$sendmePath' has been permanently added to user PATH." -ForegroundColor Green


### PR DESCRIPTION
This PR adds a PowerShell script (install-sendme.ps1) to allow Windows users to easily download and install the sendme tool, as well as add it to their PATH automatically.


**Changes:**

- Added install-sendme.ps1 to the root directory for Windows installation.
- Users can now install sendme by running a simple PowerShell command.


**Notes:**

- This update is specifically for Windows users.
- The script adds the sendme folder to the system PATH, which will allow running sendme from any terminal without specifying its full path.


**Testing:**
Tested the script on a Windows machine with the following outcomes:
- Successfully downloaded and extracted the sendme executable.
- Verified that the folder was added to the system PATH.
- Confirmed that running the sendme command from anywhere worked as expected.


New Installation Command (Once merged):
```
iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/n0-computer/sendme/main/install-sendme.ps1'))
```