### PR TITLE
Update `--relay` arg description to match implementation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ pub struct CommonArgs {
 
     /// The relay URL to use as a home relay,
     ///
-    /// Can be set to "disable" to disable relay servers and "default"
+    /// Can be set to "disabled" to disable relay servers and "default"
     /// to configure default servers.
     #[clap(long, default_value_t = RelayModeOption::Default)]
     pub relay: RelayModeOption,


### PR DESCRIPTION
Arg parser thinks that the help-suggested value is a URL, since it didn't fit in any other enum value

![image](https://github.com/user-attachments/assets/921cb2fa-b8a0-4a02-9422-e2daea5e881b)

Implementation:
https://github.com/n0-computer/sendme/blob/fdb03b324cbe8d4e4ceb25c628df75f88d0edf93/src/main.rs#L138

Comment:
https://github.com/n0-computer/sendme/blob/fdb03b324cbe8d4e4ceb25c628df75f88d0edf93/src/main.rs#L128
