### PR TITLE
fix: Fix hazmat panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,14 +280,14 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.13.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f7a89a8ee5889d2593ae422ce6e1bb03e48a0e8a16e4fa0882dfcbe7e182ef"
+checksum = "ff16d65e48353db458be63ee395c03028f24564fd48668389bd65fd945f5ac36"
 dependencies = [
+ "blake3",
  "bytes",
  "futures-lite",
  "genawaiter",
- "iroh-blake3",
  "iroh-io",
  "positioned-io",
  "range-collections",
@@ -330,6 +330,19 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
+name = "blake3"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -2037,27 +2050,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-blake3"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbba31f40a650f58fa28dd585a8ca76d8ae3ba63aacab4c8269004a0c803930"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
-]
-
-[[package]]
 name = "iroh-blobs"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d7a6872c7ec4a2613d0386b4dc19b5f3cf4822d81361c5136a63fd56ba2372"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "async-channel",
  "bao-tree",
+ "blake3",
  "bytes",
  "chrono",
  "data-encoding",
@@ -2070,7 +2069,6 @@ dependencies = [
  "hex",
  "iroh",
  "iroh-base",
- "iroh-blake3",
  "iroh-io",
  "iroh-metrics",
  "nested_enum_utils",
@@ -2103,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-io"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e302c5ad649c6a7aa9ae8468e1c4dc2469321af0c6de7341c1be1bdaab434b"
+checksum = "e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a"
 dependencies = [
  "bytes",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ derive_more = { version = "1.0.0", features = [
 futures-buffered = "0.2.4"
 futures-lite = "2.3.0"
 indicatif = "0.17.7"
-iroh-blobs = { version = "0.34", features = ["net_protocol"] }
+iroh-blobs = { version = "0.34.1", features = ["net_protocol"], path = "../iroh-blobs" }
 iroh-io = "0.6"
 iroh = "0.34"
 num_cpus = "1.16.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -610,6 +610,10 @@ async fn send(args: SendArgs) -> anyhow::Result<()> {
         );
         std::process::exit(1);
     }
+    if cwd.join(&args.path) == cwd {
+        println!("can not share from the current directory");
+        std::process::exit(1);
+    }
 
     tokio::fs::create_dir_all(&blobs_data_dir).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,7 @@ pub enum Commands {
     Send(SendArgs),
 
     /// Receive a file or directory.
+    #[clap(visible_alias = "recv")]
     Receive(ReceiveArgs),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,15 @@
 //! Command line arguments.
 
+use std::{
+    collections::BTreeMap,
+    fmt::{Display, Formatter},
+    net::{SocketAddrV4, SocketAddrV6},
+    path::{Component, Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
+
 use anyhow::Context;
 use arboard::Clipboard;
 use clap::{
@@ -32,15 +42,6 @@ use iroh_blobs::{
 use n0_future::{future::Boxed, StreamExt};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::BTreeMap,
-    fmt::{Display, Formatter},
-    net::{SocketAddrV4, SocketAddrV6},
-    path::{Component, Path, PathBuf},
-    str::FromStr,
-    sync::Arc,
-    time::Duration,
-};
 use walkdir::WalkDir;
 
 /// Send a file or directory between two machines, using blake3 verified streaming.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -136,3 +136,17 @@ fn send_recv_dir() {
         }
     }
 }
+
+#[test]
+fn send_send_current() {
+    let src_dir = tempfile::tempdir().unwrap();
+    let output = duct::cmd(sendme_bin(), ["send", "."])
+        .dir(src_dir.path())
+        .env_remove("RUST_LOG") // disable tracing
+        .stderr_to_stdout()
+        .unchecked()
+        .run()
+        .unwrap();
+    // attempting to send the current directory should fail
+    assert_eq!(output.status.code(), Some(1));
+}


### PR DESCRIPTION
Fixes https://github.com/n0-computer/sendme/issues/87

Unrelated changes:
- add a check to prevent people from sharing `.`. Once we have the store fully in mem this would be allowed, but not yet.
- add a `recv` alias for receive, since I keep entering `sendme recv`...

Todo:
- [ ] publish new iroh-blobs and depend on it