### PR TITLE
 Add zstd file compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+dependencies = [
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +358,8 @@ version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -2044,6 +2060,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +2755,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnet_base"
@@ -3521,6 +3553,7 @@ name = "sendme"
 version = "0.26.0"
 dependencies = [
  "anyhow",
+ "async-compression",
  "base64",
  "clap",
  "console",
@@ -3540,6 +3573,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -5272,4 +5306,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ data-encoding = "2.6.0"
 n0-future = "0.1.2"
 base64 = { version = "0.22.1", optional = true }
 hex = "0.4.3"
+async-compression = { version = "0.4.25", features = ["tokio", "zstd"], optional = true }
+tokio-util = { version = "0.7.15",optional = true }
 
 [dev-dependencies]
 duct = "0.13.6"
@@ -47,4 +49,5 @@ tempfile = "3.8.1"
 
 [features]
 clipboard = ["dep:base64"]
-default = ["clipboard"]
+zstd = ["async-compression","tokio-util"]
+default = ["clipboard","zstd"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -619,10 +619,7 @@ async fn export(
                 })
                 .filter_map(|res| match res {
                     EncodedItem::Leaf(leaf) => Some(Ok(leaf.data)),
-                    EncodedItem::Error(err) => Some(Err(tokio::io::Error::new(
-                        tokio::io::ErrorKind::Other,
-                        err.to_string(),
-                    ))),
+                    EncodedItem::Error(err) => Some(Err(tokio::io::Error::other(err.to_string()))),
                     _ => None,
                 });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -854,7 +854,7 @@ async fn send(args: SendArgs) -> anyhow::Result<()> {
         let compression_quality = args.common.compression_quality.clamp(1, 22);
 
         #[cfg(not(feature = "zstd"))]
-        let compression_level = 0;
+        let compression_quality = 0;
 
         let import_result = import(
             path2,
@@ -1204,7 +1204,7 @@ async fn receive(args: ReceiveArgs) -> anyhow::Result<()> {
             if let Some(first) = name.split('/').next() {
                 println!(
                     "exporting to {first}{}",
-                    if do_decompress != args.common.zstd {
+                    if do_decompress != args.common.zstd && collection.len() == 1 {
                         ".zst"
                     } else {
                         ""


### PR DESCRIPTION
This pull request adds support for compressing files before sending them using Zstandard. Compression is enabled with the `-z` flag, and the compression quality can be configured via the `-q` flag.

The feature is gated behind the zstd feature flag. Removing this feature disables compression support entirely.

This change introduces a new dependency on the [`async-compression`](https://crates.io/crates/async-compression) crate.

If a user attempts to send compressed files to a build that does not support zstd decompression, the system will add a .zst extension to each file and display the following warning:

```
Warning: This build does not support zstd decompression. Files will be saved with a `.zst` extension. 
You can manually decompress them using `unzstd <filename>`.
```