### PR TITLE
chore: bump release profile to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,11 @@ tempfile = "3.8.1"
 [features]
 clipboard = ["dep:crossterm", "dep:windows-sys", "dep:libc"]
 default = ["clipboard"]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+codegen-units = 1
+lto = true
+debug = "none"
+strip = true


### PR DESCRIPTION
Based on https://github.com/n0-computer/dumbpipe/pull/78

From `24M` to `8.4M` on my machine.