### PR TITLE
feat: Add zstd compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +357,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -478,6 +493,29 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+dependencies = [
+ "compression-core",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+
+[[package]]
+name = "concat_const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c92cd5ec953d0542f48d2a90a25aa2828ab1c03217c1ca077000f3af15997d"
 
 [[package]]
 name = "console"
@@ -2082,6 +2120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,6 +2829,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pnet_base"
@@ -3532,7 +3586,9 @@ name = "sendme"
 version = "0.29.0"
 dependencies = [
  "anyhow",
+ "async-compression",
  "clap",
+ "concat_const",
  "console",
  "crossterm",
  "data-encoding",
@@ -5395,4 +5451,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ walkdir = "2.4.0"
 data-encoding = "2.6.0"
 n0-future = "0.1.2"
 hex = "0.4.3"
+async-compression = { version = "0.4.25", features = ["tokio", "zstd"], optional = true }
+concat_const = { version = "0.2.0", optional = true}
 crossterm = { version = "0.29.0", features = [
   "event-stream",
   "osc52",
@@ -56,8 +58,9 @@ serde_json = "1.0.108"
 tempfile = "3.8.1"
 
 [features]
+zstd = ["async-compression","concat_const"]
 clipboard = ["dep:crossterm", "dep:windows-sys", "dep:libc"]
-default = ["clipboard"]
+default = ["clipboard","zstd"]
 
 [profile.release]
 panic = "abort"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1331,7 +1331,7 @@ async fn receive(args: ReceiveArgs) -> anyhow::Result<()> {
                         HumanBytes(total_size)
                     );
                 }
-                (total_files, payload_size, total_files)
+                (total_size, payload_size, total_files)
             } else {
                 (0, 0, 0)
             };


### PR DESCRIPTION
This PR adds support for compressing files during transfers using zstd, using the new abstract stream API merged in [iroh-blobs#147](https://github.com/n0-computer/iroh-blobs/pull/147).

Compression can be enabled with the `-z` flag, and the compression quality can be configured via the `-q` flag. The feature is gated behind the zstd feature flag, disabling this flag removes compression support entirely. This change also introduces a new dependency on the [async-compression](https://crates.io/crates/async-compression) crate. 

When sending with `-z`, the progress bars are currently non-functional. This is because the `get_hash_seq_and_sizes` function directly takes a connection rather than something that implements the `GetStreamPair` trait. As a result, it bypasses the abstraction used to wrap streams for compression. Unless there’s an alternative path I’ve missed